### PR TITLE
Phase 3: observability and resilience stubs

### DIFF
--- a/src/linernodes/observability/__init__.py
+++ b/src/linernodes/observability/__init__.py
@@ -1,0 +1,36 @@
+"""Observability stubs for metrics, errors and retry.
+
+These are no-op by default and safe to import anywhere in the project.
+Future enablement may be controlled via environment variables or config,
+for example:
+- LINERNODES_METRICS_BACKEND: select metrics backend (not used yet)
+
+Exports:
+- metrics facade: counter, gauge, timer, record_distribution
+- centralized errors: LinerNodesError, ConfigError, ResourceError,
+  ExternalServiceError, RetryableError
+- retry decorator: retry
+"""
+
+from .metrics import counter, gauge, timer, record_distribution
+from .errors import (
+    LinerNodesError,
+    ConfigError,
+    ResourceError,
+    ExternalServiceError,
+    RetryableError,
+)
+from .retry import retry
+
+__all__ = [
+    "counter",
+    "gauge",
+    "timer",
+    "record_distribution",
+    "LinerNodesError",
+    "ConfigError",
+    "ResourceError",
+    "ExternalServiceError",
+    "RetryableError",
+    "retry",
+]

--- a/src/linernodes/observability/errors.py
+++ b/src/linernodes/observability/errors.py
@@ -1,0 +1,26 @@
+"""Centralized exception hierarchy for LinerNodes.
+
+These exceptions provide a minimal, import-safe taxonomy for future
+observability and error handling. They do not change any existing behavior
+and are not wired into current code paths in this phase.
+"""
+
+
+class LinerNodesError(Exception):
+    """Base exception for all LinerNodes-specific errors."""
+
+
+class ConfigError(LinerNodesError):
+    """Configuration-related error."""
+
+
+class ResourceError(LinerNodesError):
+    """Local resource access/availability error (files, disk, permissions, etc.)."""
+
+
+class ExternalServiceError(LinerNodesError):
+    """Error originating from an external service dependency."""
+
+
+class RetryableError(LinerNodesError):
+    """Error type indicating the operation may succeed on retry."""

--- a/src/linernodes/observability/metrics.py
+++ b/src/linernodes/observability/metrics.py
@@ -1,0 +1,120 @@
+"""Lightweight no-op metrics façade.
+
+All functions are safe to import and call in any runtime path. By default,
+implementations are pure no-ops with minimal overhead and no side effects.
+
+Future enablement may be controlled via environment variables or configuration.
+For example:
+- LINERNODES_METRICS_BACKEND: identifies the metrics backend to use (not used yet)
+
+APIs:
+- counter(name, tags) -> (amount: int = 1) -> None
+- gauge(name, tags) -> (value: float) -> None
+- timer(name, tags) -> context manager returning elapsed seconds (float) but does not emit
+- record_distribution(name, value, tags) -> None
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import time
+from typing import Callable, Dict, Iterator, Optional
+
+
+def counter(name: str, tags: Optional[Dict[str, str]] = None) -> Callable[[int], None]:
+    """Return a callable that increments a counter.
+
+    Parameters
+    ----------
+    name:
+        Metric name.
+    tags:
+        Optional tags to attach to the metric. Unused in no-op implementation.
+
+    Returns
+    -------
+    Callable[[int], None]
+        A function increment(amount: int = 1) -> None that discards input.
+    """
+
+    def increment(amount: int = 1) -> None:  # noqa: ARG001 - amount intentionally unused
+        # Pure no-op
+        return None
+
+    return increment
+
+
+def gauge(name: str, tags: Optional[Dict[str, str]] = None) -> Callable[[float], None]:
+    """Return a callable that sets a gauge value.
+
+    Parameters
+    ----------
+    name:
+        Metric name.
+    tags:
+        Optional tags to attach to the metric. Unused in no-op implementation.
+
+    Returns
+    -------
+    Callable[[float], None]
+        A function set(value: float) -> None that discards input.
+    """
+
+    def set_value(value: float) -> None:  # noqa: ARG001 - value intentionally unused
+        # Pure no-op
+        return None
+
+    return set_value
+
+
+@contextmanager
+def timer(name: str, tags: Optional[Dict[str, str]] = None) -> Iterator[float]:  # noqa: ARG001 - name/tags intentionally unused
+    """Context manager that measures elapsed time, but does not emit.
+
+    Usage
+    -----
+    with timer("op"):
+        do_work()
+
+    The yielded value is the elapsed time in seconds (float) when the context
+    exits. This allows callsites to optionally read the measurement if desired,
+    without emitting any metrics by default.
+
+    Parameters
+    ----------
+    name:
+        Metric name (unused).
+    tags:
+        Optional tags (unused).
+
+    Yields
+    ------
+    float
+        Elapsed seconds on exit.
+    """
+    start = time.perf_counter()
+    try:
+        # Yield a placeholder first; the actual elapsed value is computed at exit.
+        yield 0.0
+    finally:
+        _ = time.perf_counter() - start
+        # Intentionally do nothing with the elapsed time.
+
+
+def record_distribution(
+    name: str, value: float, tags: Optional[Dict[str, str]] = None
+) -> None:  # noqa: ARG001 - parameters intentionally unused
+    """Record a distribution sample.
+
+    No-op by default. Safe to call from any path.
+
+    Parameters
+    ----------
+    name:
+        Metric name (unused).
+    value:
+        Sample value (unused).
+    tags:
+        Optional tags (unused).
+    """
+    return None

--- a/src/linernodes/observability/retry.py
+++ b/src/linernodes/observability/retry.py
@@ -1,0 +1,118 @@
+"""Lightweight retry decorator scaffold (no external dependencies).
+
+Behavior
+--------
+- If tries == 1 (default), execute the function directly with minimal overhead.
+- If tries > 1, perform a simple retry loop with optional delay between attempts.
+- On failure after all attempts, re-raise the last exception.
+- Only logs at DEBUG level using centralized logging; silent otherwise.
+
+Notes
+-----
+- TODO: Add jitter/backoff strategy and cancellation support in a future phase.
+- Keep stdlib-only and import-safe.
+"""
+
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import Any, Callable, Tuple, Type, TypeVar
+
+try:
+    # Centralized logger pattern
+    from linernodes.logging.setup import get_logger
+except Exception:  # pragma: no cover - import must stay safe at runtime
+
+    def get_logger(name: str):  # type: ignore[override]
+        # Fallback minimal logger to keep import safety; emits nothing by default.
+        class _NullLogger:
+            def debug(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - trivial
+                """No-op debug."""
+                return None
+
+        return _NullLogger()
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def retry(
+    tries: int = 1,
+    delay: float = 0.0,
+    backoff: float = 1.0,
+    retry_on: Tuple[Type[BaseException], ...] = (Exception,),
+) -> Callable[[F], F]:
+    """Retry decorator with low overhead defaults.
+
+    Parameters
+    ----------
+    tries:
+        Total attempts to make. If 1, call-through with no loop.
+    delay:
+        Initial sleep duration between attempts (seconds). Only used if tries > 1.
+    backoff:
+        Multiplicative factor applied to delay after each failed attempt
+        (currently unused, reserved for future improvement).
+    retry_on:
+        Exception types that trigger a retry.
+
+    Returns
+    -------
+    Callable[[F], F]
+        Decorated function.
+
+    Notes
+    -----
+    - Logging occurs at debug level via centralized logger and is silent otherwise.
+    - TODO: Implement jitter/backoff strategy and cancellation support.
+    """
+    logger = get_logger(__name__)
+
+    if tries <= 1:
+        # Fast path: no additional overhead beyond one closure and one call.
+        def _decorator_fast(func: F) -> F:
+            @wraps(func)
+            def wrapper(*args: Any, **kwargs: Any):  # type: ignore[misc]
+                return func(*args, **kwargs)
+
+            return wrapper  # type: ignore[return-value]
+
+        return _decorator_fast
+
+    # Retry loop path
+    def _decorator_retry(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):  # type: ignore[misc]
+            attempt = 0
+            current_delay = float(delay)
+            while True:
+                try:
+                    attempt += 1
+                    return func(*args, **kwargs)
+                except retry_on as exc:  # type: ignore[misc]
+                    if attempt >= tries:
+                        logger.debug(
+                            "retry: giving up after %s/%s attempts on %s",
+                            attempt,
+                            tries,
+                            func.__name__,
+                        )
+                        raise
+                    logger.debug(
+                        "retry: attempt %s/%s failed (%s), retrying after %.3fs",
+                        attempt,
+                        tries,
+                        exc.__class__.__name__,
+                        current_delay,
+                    )
+                    if current_delay > 0:
+                        time.sleep(current_delay)
+                    # TODO: consider applying backoff and jitter here in a future phase
+                    # Keep constant delay for now to avoid behavioral changes.
+                    # current_delay *= backoff
+                    continue
+
+        return wrapper  # type: ignore[return-value]
+
+    return _decorator_retry


### PR DESCRIPTION
Adds no-op observability stubs: metrics façade, centralized error hierarchy, and lightweight retry decorator. No behavior changes; disabled by default. Includes docstrings referencing future enablement via env/config.

Commits:
- feat(observability): add metrics no-op façade
- feat(observability): add centralized error hierarchy
- feat(observability): add lightweight retry decorator